### PR TITLE
Add diagonal extraction kernel for matrix-free preconditioning

### DIFF
--- a/src/FiniteElementContainers.jl
+++ b/src/FiniteElementContainers.jl
@@ -125,6 +125,8 @@ export num_states
 export reshape_element_level_field
 export unpack_field
 
+export assemble_diagonal!
+export diagonal
 export energy
 export hvp
 export mass

--- a/src/assemblers/Assemblers.jl
+++ b/src/assemblers/Assemblers.jl
@@ -27,6 +27,9 @@ end
 struct AssembledSparseVector <: AdditiveAssembledReturnType
 end
 
+struct AssembledDiagonal <: AssembledReturnType
+end
+
 @inline function _accumulate_q_value(::AdditiveAssembledReturnType, storage, val_q, val_e, q, e)
   return val_e + val_q
 end
@@ -34,6 +37,11 @@ end
 @inline function _accumulate_q_value(::IndexedAssembledReturnType, storage, val_q, val_e, q, e)
   storage[q, e] = val_q
   return nothing
+end
+
+@inline function _accumulate_q_value(::AssembledDiagonal, storage, K_q::SMatrix{N, N, T}, val_e, q, e) where {N, T}
+  diag_q = SVector{N, T}(ntuple(i -> K_q[i, i], Val(N)))
+  return val_e + diag_q
 end
 
 @inline function _accumulate_q_value(::AssembledScalar, storage::AbstractArray{T, 3}, val_q, val_e, q, e) where T
@@ -224,6 +232,12 @@ $(TYPEDSIGNATURES)
   NxNDof = NNPE * NF
   R_el = zeros(SVector{NxNDof, eltype(U)})
   return R_el
+end
+
+@inline function _element_scratch(::AssembledDiagonal, ref_fe, U::H1Field{T, D, NF}) where {T, D, NF}
+  NNPE = ReferenceFiniteElements.num_cell_dofs(ref_fe)
+  NxNDof = NNPE * NF
+  return zeros(SVector{NxNDof, eltype(U)})
 end
 
 """
@@ -456,3 +470,4 @@ include("QuadratureQuantity.jl")
 include("Source.jl")
 include("Vector.jl")
 include("WeaklyEnforcedBCs.jl")
+include("Diagonal.jl")

--- a/src/assemblers/Diagonal.jl
+++ b/src/assemblers/Diagonal.jl
@@ -1,0 +1,62 @@
+"""
+$(TYPEDSIGNATURES)
+Assemble the diagonal of a matrix (e.g., stiffness or mass) into the
+assembler's residual storage field.  Uses the same physics function as
+`assemble_stiffness!` / `assemble_mass!` but extracts only the diagonal
+entries of the element matrix at each quadrature point, avoiding full
+sparse matrix assembly.
+
+The result is stored in the assembler's residual storage and can be
+retrieved via `diagonal(asm)`.
+
+This is essential for GPU-friendly Jacobi preconditioning: `diag(K)`
+gives the true diagonal, whereas the row-sum approximation `K·1` can
+be zero at interior nodes of uniform meshes.
+"""
+function assemble_diagonal!(
+  assembler, func::F, Uu, p
+) where F <: Function
+  storage = assembler.residual_storage
+  fill!(storage, zero(eltype(storage)))
+  dof = assembler.dof
+  fspace = function_space(dof)
+  X = coordinates(p)
+  t = current_time(p)
+  Δt = time_step(p)
+  U = p.field
+  U_old = p.field_old
+  _update_for_assembly!(p, dof, Uu)
+  return_type = AssembledDiagonal()
+  conns = fspace.elem_conns
+  foreach_block(fspace, p) do physics, props, ref_fe, b
+    _assemble_block!(
+      storage,
+      conns.data, conns.offsets[b],
+      func,
+      physics, ref_fe,
+      X, t, Δt,
+      U, U_old,
+      block_view(p.state_old, b), block_view(p.state_new, b), props,
+      return_type
+    )
+  end
+  return nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+Return the assembled diagonal vector after a call to `assemble_diagonal!`.
+Extracts the unknown DOF subset (non-condensed) or the full vector (condensed).
+"""
+function diagonal(asm::AbstractAssembler)
+  if _is_condensed(asm.dof)
+    return asm.residual_storage.data
+  else
+    extract_field_unknowns!(
+      asm.residual_unknowns,
+      asm.dof,
+      asm.residual_storage
+    )
+    return asm.residual_unknowns
+  end
+end


### PR DESCRIPTION
## Summary

- Add `assemble_diagonal!` and `diagonal()` functions that compute `diag(K)` (or `diag(M)`) without assembling the full sparse matrix
- New `AssembledDiagonal` return type with specialized `_element_scratch` and `_accumulate_q_value` dispatches
- Reuses existing vector scatter pattern for GPU-compatible atomic assembly

## Motivation

The matrix-free Jacobi preconditioner in Carina.jl approximates `diag(K)` via the row-sum `K·ones`. This approximation is **zero at interior nodes of uniform meshes** where element stiffness row sums cancel, corrupting the preconditioner with `1/eps` entries and causing CG to stall.

The diagonal extraction kernel computes the true `diag(K)` by extracting only the diagonal entries of each element stiffness matrix at each quadrature point, then scatter-adding to a global vector. Same cost as one matrix-vector product but gives the exact diagonal.

## API

```julia
# Assemble diagonal of stiffness (or mass) matrix
FEC.assemble_diagonal!(asm, FEC.stiffness, U, p)
diag_K = FEC.diagonal(asm)

# Works with mass too
FEC.assemble_diagonal!(asm, FEC.mass, U, p)
diag_M = FEC.diagonal(asm)
```