### PR TITLE
Speed up sparsity-pattern sort with packed integer keys

### DIFF
--- a/src/assemblers/SparsityPatterns.jl
+++ b/src/assemblers/SparsityPatterns.jl
@@ -93,8 +93,11 @@ function SparseMatrixPattern(dof::DofManager)
   cscrowval = Vector{Int64}(undef, 0)
   cscnzval  = Vector{Float64}(undef, 0)
 
-  # set permutation
-  ks = map((i, j) -> (i, j), Is, Js)
+  # set permutation — pack (row, col) into one Int64 key so sortperm takes the
+  # integer radix-sort path instead of an O(N log N) tuple comparison sort.
+  # DOF indices are << 2^32, so the packed key preserves (i, j) lexicographic
+  # order and (sortperm being stable) yields an identical permutation.
+  ks = map((i, j) -> (Int64(i) << 32) | Int64(j), Is, Js)
   permutation = sortperm(ks)
 
   pattern = SparseMatrixPattern(
@@ -246,9 +249,11 @@ function _update_dofs!(pattern::SparseMatrixPattern, dof, dirichlet_dofs)
   resize!(pattern.csrcolval, length(pattern.Is))
   resize!(pattern.csrnzval, length(pattern.Is))
 
-  # TODO below is half of the runtime in this method
-  # it can likely be sped up
-  ks = map((i, j) -> (i, j), pattern.Is, pattern.Js)
+  # Pack (row, col) into one Int64 key so sortperm takes the integer radix-sort
+  # path instead of an O(N log N) tuple comparison sort.  DOF indices are
+  # << 2^32, so the packed key preserves (i, j) lexicographic order and
+  # (sortperm being stable) yields an identical permutation.
+  ks = map((i, j) -> (Int64(i) << 32) | Int64(j), pattern.Is, pattern.Js)
   permutation = sortperm(ks)
   resize!(pattern.permutation, length(permutation))
   pattern.permutation .= permutation


### PR DESCRIPTION
Building the COO->CSC permutation sorted a Vector{Tuple{Int64,Int64}} of all (row, col) index pairs (~92M for a 530k-DOF mesh) with sortperm, which takes an O(N log N) tuple comparison sort. Profiling a Carina torsion run showed this was ~half the runtime of both _update_dofs! and the SparseMatrixPattern constructor (the existing TODO comment already flagged it).

Pack each (i, j) into a single Int64 key, (Int64(i) << 32) | Int64(j), so sortperm takes the integer radix-sort path instead. DOF indices are well below 2^32, so the packed key preserves (i, j) lexicographic order; sortperm being stable, the resulting permutation is identical.

Applied at both sites in SparsityPatterns.jl (SparseMatrixPattern construction and _update_dofs!). On a 530k-DOF torsion problem this cut assembler build 5.0s -> 3.4s and parameter build 7.4s -> 3.9s. Carina test suite: 106/106 pass, all results bit-identical.