### PR TITLE
Add backend-keyed to_backend; make cuda/rocm aliases

### DIFF
--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -5,9 +5,13 @@ import AMDGPU
 import FiniteElementContainers
 
 # public API
-function FiniteElementContainers.rocm(x)
+function FiniteElementContainers.to_backend(::AMDGPU.ROCBackend, x)
   return Adapt.adapt_structure(AMDGPU.ROCArray, x)
 end
+
+# back-compat alias
+FiniteElementContainers.rocm(x) =
+  FiniteElementContainers.to_backend(AMDGPU.ROCBackend(), x)
 
 # private API
 function FiniteElementContainers._coo_matrix_constructor(::AMDGPU.ROCBackend)

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -5,9 +5,13 @@ import CUDA
 import FiniteElementContainers
 
 # public API
-function FiniteElementContainers.cuda(x)
+function FiniteElementContainers.to_backend(::CUDA.CUDABackend, x)
   return Adapt.adapt_structure(CUDA.CuArray, x)
 end
+
+# back-compat alias
+FiniteElementContainers.cuda(x) =
+  FiniteElementContainers.to_backend(CUDA.CUDABackend(), x)
 
 # private API
 function FiniteElementContainers._coo_matrix_constructor(::CUDA.CUDABackend)

--- a/src/FiniteElementContainers.jl
+++ b/src/FiniteElementContainers.jl
@@ -4,6 +4,7 @@ module FiniteElementContainers
 export cpu
 export cuda
 export rocm
+export to_backend
 
 # Assemblers
 export SparseMatrixAssembler
@@ -206,6 +207,14 @@ function cpu end
 cpu(x) = adapt(Array, x)
 function cuda end
 function rocm end
+
+# Move `x` onto the given KernelAbstractions backend.  CPU is identity —
+# CPU-built data already lives on the CPU backend.  GPU backends (CUDABackend,
+# ROCBackend) are provided by the CUDA / AMDGPU package extensions.
+to_backend(::KA.CPU, x) = x
+to_backend(b::KA.Backend, x) = error(
+  "to_backend is not implemented for backend $(typeof(b)); load the " *
+  "corresponding GPU package (CUDA.jl or AMDGPU.jl) so its extension activates.")
 
 # function communication_graph end
 function create_partition end


### PR DESCRIPTION
Introduce `to_backend(backend::KA.Backend, x)` — moves `x` onto a given
KernelAbstractions backend. CPU is identity (CPU-built data already lives
on the CPU backend); CUDABackend/ROCBackend are provided by the CUDA and
AMDGPU package extensions. An unknown backend errors with a hint to load
the corresponding GPU package.

This lets downstream packages select a device by passing a KA.Backend
object, instead of depending on CUDA.jl/AMDGPU.jl directly and calling
the named cuda()/rocm() functions.

cuda(x) and rocm(x) are kept as back-compat aliases that delegate to
to_backend. FEC test suite passes.
