### PR TITLE
Make GPU usable for problems with boundary and initial conditions

### DIFF
--- a/src/Expressions.jl
+++ b/src/Expressions.jl
@@ -601,14 +601,24 @@ end
 
 # IC-style call: ND spatial coords (no time variable in the expression).
 function (f::ScalarExpressionFunction{T})(X::SVector{ND, T}) where {ND, T <: Number}
-    @assert Int(f.num_vars) == ND "You need $ND variables for this function"
+    # See the note on the (X, t) method below: no interpolation in this message.
+    # `_update_ic_values!` dispatches on the IC container's backend, so this call
+    # lands inside a KA kernel whenever the parameters live on the device.
+    @assert Int(f.num_vars) == ND "wrong number of variables for this expression"
     return _eval_node(f.nodes, UInt16(1), X)
 end
 
 # BC-style call: ND spatial coords + scalar time, packed into a stack-
 # allocated SVector so the call survives KA kernels.
 function (f::ScalarExpressionFunction{T})(X::SVector{ND, T}, t::T) where {ND, T <: Number}
-    @assert Int(f.num_vars) == ND + 1 "You need $(ND + 1) variables for this function"
+    # NOTE: the message must not interpolate.  This method is called from inside
+    # KA kernels (`_update_bc_values!` and the periodic-BC equivalent dispatch on
+    # the device-resident container), and building an interpolated string on the
+    # failure branch emits IR that GPUCompiler rejects.  That made every
+    # Dirichlet BC unusable on GPU, and surfaced as a segfault rather than a
+    # readable error because GPUCompiler crashed while formatting the report.  A
+    # literal message compiles to a trap and is fine.
+    @assert Int(f.num_vars) == ND + 1 "wrong number of variables for this expression"
     if ND == 1
         vars = SVector{2, T}(X[1], t)
     elseif ND == 2

--- a/src/InitialConditions.jl
+++ b/src/InitialConditions.jl
@@ -83,6 +83,15 @@ struct InitialConditionContainer{
         vals = zeros(length(dofs))
         new{typeof(dofs), typeof(vals)}(dofs, nodes, vals)
     end
+
+    # Field-wise constructor, mirroring DirichletBCContainer.  Declaring the
+    # constructor above suppresses Julia's default one, so without this
+    # `adapt_structure` below has no method to call and moving a parameter set
+    # containing initial conditions to a device fails with a MethodError -- i.e.
+    # initial conditions could not be placed on a GPU at all.
+    function InitialConditionContainer(dofs, locations, vals)
+        new{typeof(dofs), typeof(vals)}(dofs, locations, vals)
+    end
 end
 
 function Adapt.adapt_structure(to, ic::InitialConditionContainer)

--- a/test/TestBCs.jl
+++ b/test/TestBCs.jl
@@ -299,4 +299,31 @@ end
   for dev in gpu_backends
     @test bc_values(dev) ≈ reference
   end
+
+  # Initial conditions go through the same evaluator by a different route:
+  # `initialize!` calls `update_ic_values!`, and `_update_ic_values!` dispatches
+  # on the IC container's backend, so a device-resident parameter set evaluates
+  # the expression in a kernel too. That overload takes coordinates only (no
+  # time), so num_vars must equal ND rather than ND + 1.
+  ic_expr = ScalarExpressionFunction{Float64}("4.0 * x + 5.0 * y", ["x", "y"])
+
+  function ic_values(dev)
+    asm = SparseMatrixAssembler(u; sparse_matrix_type = :csc, use_inplace_methods = false)
+    p = create_parameters(mesh, asm, physics, props;
+                          ics = InitialCondition[InitialCondition("u", ic_expr; block_name = "block_1")])
+    if dev != cpu
+      p = p |> dev
+      asm = asm |> dev
+    end
+    FiniteElementContainers.initialize!(p)
+    p = dev == cpu ? p : (p |> cpu)
+    return Array(p.field.data)
+  end
+
+  ic_reference = ic_values(cpu)
+  @test any(!iszero, ic_reference)
+
+  for dev in gpu_backends
+    @test ic_values(dev) ≈ ic_reference
+  end
 end

--- a/test/TestBCs.jl
+++ b/test/TestBCs.jl
@@ -247,3 +247,56 @@ end
   # source_in = Source("disp", dummy_func_2, "block_1")
   # @test_throws E Sources(mesh, dof, Source[source_in])
 end
+
+@testitem "BCs - dirichlet expression functions compile in GPU kernels" tags=[:gpu] begin
+  if "--test-amdgpu" in ARGS @eval using AMDGPU end
+  if "--test-cuda" in ARGS @eval using CUDA end
+  using StaticArrays
+  import FiniteElementContainers.Expressions: ScalarExpressionFunction
+  include("TestUtils.jl")
+  include("poisson/TestPoissonCommon.jl")
+
+  # `_update_bc_values!` dispatches on the device-resident BC container, so a
+  # Dirichlet BC function is evaluated inside a KA kernel on every time step.
+  # Every other GPU test in this suite supplies a plain closure such as
+  # `bc_func(_, _) = 0.`, which compiles without trouble.  A parsed
+  # `ScalarExpressionFunction` -- what an input-file driven application actually
+  # passes -- did not: its call overload asserted with an interpolated message,
+  # and building that string on the failure branch emits IR GPUCompiler rejects.
+  # Dirichlet BCs were therefore unusable on GPU for any file-driven problem
+  # while this suite stayed green, so pin the expression path specifically.
+  backends = _get_backends()
+  gpu_backends = filter(!=(cpu), backends)
+  isempty(gpu_backends) && return nothing
+
+  mesh = UnstructuredMesh("poisson/poisson.g")
+  V = FunctionSpace(mesh, H1Field, Lagrange)
+  u = ScalarFunction(V, "u")
+  physics = Poisson((X, _) -> 0.0)
+  props = create_properties(physics)
+
+  # Time is the last variable by convention, and the mesh is 2D, so num_vars
+  # must be ND + 1 = 3.  Deliberately depends on x, y and t so a mix-up in the
+  # packed SVector cannot cancel out.
+  expr = ScalarExpressionFunction{Float64}("2.0 * t * x + 3.0 * y", ["x", "y", "t"])
+
+  function bc_values(dev)
+    asm = SparseMatrixAssembler(u; sparse_matrix_type = :csc, use_inplace_methods = false)
+    dbcs = DirichletBC[DirichletBC("u", expr; sideset_name = "sset_1")]
+    p = create_parameters(mesh, asm, physics, props; dirichlet_bcs = dbcs)
+    if dev != cpu
+      p = p |> dev
+      asm = asm |> dev
+    end
+    update_bc_values!(p, asm)
+    p = dev == cpu ? p : (p |> cpu)
+    return Array(p.dirichlet_bcs.bc_cache.vals)
+  end
+
+  reference = bc_values(cpu)
+  @test any(!iszero, reference)          # the expression must actually do something
+
+  for dev in gpu_backends
+    @test bc_values(dev) ≈ reference
+  end
+end


### PR DESCRIPTION
Two interlocking bugs meant the GPU path could not run any problem carrying
boundary conditions from an input file, and could not carry initial conditions
at all. Every GPU example in this repo and downstream is initial-condition
driven with no Dirichlet BCs, which is why both survived.

## Expression functions could not compile inside kernels

`_update_bc_values!` dispatches on the device-resident BC container, so a BC
function is evaluated inside a KA kernel on every time step.
`ScalarExpressionFunction`'s call overload asserted with an interpolated
message, and building that string on the failure branch emits IR GPUCompiler
rejects, so the kernel never compiled.

It surfaced as a segmentation fault rather than a readable error, because
GPUCompiler crashed while formatting the `InvalidIRError` it was about to
report. A literal message compiles to a trap, so the check itself stays.

Both overloads kernels can reach are fixed: `(X, t)`, reached through Dirichlet
and periodic BCs, and `(X)`, reached through `_update_ic_values!`. The
remaining asserts in that file sit on parser and `AbstractVector` paths that
kernels never reach -- the SVector methods are more specific -- and keep their
interpolated messages.

## Initial conditions could not be adapted to a device

`InitialConditionContainer` declares only the `(mesh, dof, ic)` inner
constructor, which suppresses Julia's default field-wise one, so
`adapt_structure` had no method to call and moving a parameter set containing
initial conditions to a GPU failed with a `MethodError`.

This is why the `(X)` overload above had never failed on GPU despite carrying
the same defect: the path was unreachable. `DirichletBCContainer` carries the
field-wise constructor alongside its richer one, which is why Dirichlet BCs
adapt cleanly; this mirrors it.

## Why the suite did not catch a total GPU outage

Every GPU test here supplies a plain closure such as `bc_func(_, _) = 0.`,
which compiles without trouble. Only a parsed expression -- what an
input-file driven application actually passes -- carried the bad assert.

The new `:gpu`-tagged test pins that specific combination, and drives both
routes into the evaluator: a Dirichlet BC from `"2.0 * t * x + 3.0 * y"`
through `update_bc_values!`, and an initial condition from
`"4.0 * x + 5.0 * y"` through `initialize!`. Both are compared against the
host result, and each asserts its reference is non-zero so neither can pass
vacuously.

## Verification

- Full suite under `--test-amdgpu`: 85196 passed.
- Reverting the first commit makes the new test fail with the exact
  `InvalidIRError` on `_update_bc_values!` specialized for
  `ScalarExpressionFunction`, so it genuinely guards the regression.
- I audited the rest of the package for the same defect class: all 31 kernel
  entry points, the helpers they call, and all 28 interpolated assert/error
  sites in `src/` and `ext/`. Everything else is host-side (parser, symbolic
  differentiation, assembler and sparsity construction, mesh I/O, SimpleYAML).
  These two were the only reachable instances.