### PR TITLE
Add as_matrix_free for lean device transfers

### DIFF
--- a/src/FiniteElementContainers.jl
+++ b/src/FiniteElementContainers.jl
@@ -8,6 +8,7 @@ export to_backend
 
 # Assemblers
 export SparseMatrixAssembler
+export as_matrix_free
 export create_assembler_cache
 export assemble_lumped_mass!
 export assemble_mass!

--- a/src/assemblers/SparseMatrixAssembler.jl
+++ b/src/assemblers/SparseMatrixAssembler.jl
@@ -159,6 +159,43 @@ end
 # pattern and matrix-value buffers are empty and assemble_matrix! is forbidden.
 _is_matrix_free(asm::SparseMatrixAssembler) = isempty(asm.matrix_pattern.Is)
 
+"""
+$(TYPEDSIGNATURES)
+Return a matrix-free view of `asm`: a new `SparseMatrixAssembler` sharing all
+of `asm`'s fields except the sparse matrix pattern and the mass/stiffness value
+buffers, which are replaced by the same empty placeholders an assembler
+constructed with `matrix_free = true` carries.  The original assembler is
+untouched and can still assemble matrices.
+
+Intended use: solvers that only ever run matrix-free operations on a device
+(`assemble_matrix_free_action!`, `assemble_diagonal!`, `assemble_vector!`, ...)
+should transfer `as_matrix_free(asm)` instead of `asm` — the pattern and value
+buffers dominate the assembler's memory footprint (roughly 25x the matrix-free
+remainder at ~500k DOFs) and are dead weight there.  Call on a host-resident
+assembler, before `to_backend`; the empty placeholders are host arrays.
+"""
+function as_matrix_free(asm::SparseMatrixAssembler)
+  _is_matrix_free(asm) && return asm
+  return SparseMatrixAssembler{
+    _is_condensed(asm.dof),
+    _sparse_matrix_type(asm),
+    _use_inplace_methods(asm),
+    _use_sparse_vector(asm)
+  }(
+    asm.dof,
+    _empty_matrix_pattern(asm.dof),
+    asm.vector_pattern,
+    asm.constraint_storage,
+    similar(asm.mass_storage, 0),
+    asm.residual_storage,
+    asm.residual_unknowns,
+    asm.scalar_quadrature_storage,
+    similar(asm.stiffness_storage, 0),
+    asm.stiffness_action_storage,
+    asm.stiffness_action_unknowns
+  )
+end
+
 function Adapt.adapt_structure(to, asm::SparseMatrixAssembler)
   return SparseMatrixAssembler{
     _is_condensed(asm.dof),

--- a/test/TestAssemblers.jl
+++ b/test/TestAssemblers.jl
@@ -340,6 +340,66 @@ end
   end
 end
 
+@testitem "Assemblers - test_as_matrix_free" setup=[AssemblerHelperMechanics] begin
+  # as_matrix_free(asm) is the transfer-time companion of matrix_free=true:
+  # a copy of a full assembler with the sparse pattern and matrix value
+  # buffers replaced by empty placeholders, so that solvers running only
+  # matrix-free operations on a device don't ship the dominant (and there
+  # unused) part of the assembler's memory to it.
+  include("TestUtils.jl")
+  using LinearAlgebra: diag
+  backends = _get_backends()
+
+  # Assembled gold reference on the full CPU assembler.
+  asm_full = SparseMatrixAssembler(u)
+  p = create_parameters(mesh, asm_full, physics, props; dirichlet_bcs = dbcs, times = times)
+  FiniteElementContainers.initialize!(p)
+  Uu = create_unknowns(asm_full)
+  assemble_stiffness!(asm_full, stiffness, Uu, p)
+  K_ref = copy(stiffness(asm_full))
+  d_ref = diag(K_ref)
+
+  asm_mf = as_matrix_free(asm_full)
+
+  # Matrix-side storage is stripped; everything else is shared, not copied.
+  @test FiniteElementContainers._is_matrix_free(asm_mf)
+  @test isempty(asm_mf.matrix_pattern.Is)
+  @test isempty(asm_mf.mass_storage)
+  @test isempty(asm_mf.stiffness_storage)
+  @test asm_mf.dof === asm_full.dof
+  @test asm_mf.vector_pattern === asm_full.vector_pattern
+  @test asm_mf.constraint_storage === asm_full.constraint_storage
+  @test asm_mf.residual_storage === asm_full.residual_storage
+  @test asm_mf.stiffness_action_storage === asm_full.stiffness_action_storage
+
+  # Idempotent on an already matrix-free assembler; original keeps its pattern.
+  @test as_matrix_free(asm_mf) === asm_mf
+  @test !FiniteElementContainers._is_matrix_free(asm_full)
+
+  # Matrix assembly on the stripped assembler must fail loudly.
+  @test_throws ErrorException assemble_stiffness!(asm_mf, stiffness, Uu, p)
+  @test_throws ErrorException create_assembler_cache(
+    asm_mf, FiniteElementContainers.AssembledMatrix()
+  )
+
+  # The matrix-free operations the stripped assembler exists for must still
+  # match the assembled reference, on every available backend.
+  for dev in backends
+    asm_d = asm_mf |> dev
+    p_d   = p      |> dev
+    Uu_d = create_unknowns(asm_d)
+    Vu_d = create_unknowns(asm_d)
+    fill!(Vu_d, 1.0)
+
+    assemble_matrix_free_action!(asm_d, stiffness_action, Uu_d, Vu_d, p_d)
+    Kv = Array(hvp(asm_d, Vu_d))
+    @test Kv ≈ K_ref * ones(length(Kv))
+
+    assemble_diagonal!(asm_d, stiffness, Uu_d, p_d)
+    @test Array(diagonal(asm_d)) ≈ d_ref
+  end
+end
+
 @testitem "Assemblers - test_matrix_free_action_full_mechanics" setup=[AssemblerHelperMechanics] begin
   # The contract on assemble_matrix_free_action_full!:
   #   (a) Equivalence to the assembled gold reference: on free rows the


### PR DESCRIPTION
## Summary

A solver that only runs matrix-free operations on a device still shipped the full assembled-matrix apparatus there when moving an assembler with `to_backend`: at ~530k DOFs the sparse pattern plus the mass/stiffness value buffers are ~5.6 GB of a 5.8 GB device footprint, none of it ever read by the matrix-free paths.

This adds an exported `as_matrix_free(asm)` that returns a `SparseMatrixAssembler` sharing every field of the original except the sparse pattern and the mass/stiffness value buffers, which are replaced by the same empty placeholders an assembler constructed with `matrix_free = true` carries. Callers can transfer `as_matrix_free(asm)` instead of `asm` while keeping the host assembler fully capable of matrix assembly.

- Idempotent on an already matrix-free assembler.
- Matrix assembly on the stripped copy fails loudly through the existing `_check_matrix_assembly_supported` / `create_assembler_cache` guards.
- Intended to be called on a host-resident assembler before `to_backend` (the placeholders are host arrays); documented in the docstring.

Measured downstream (Carina, 530k-DOF Newmark torsion on ROCm): live VRAM after one step drops from 5.83 GB to 0.245 GB with identical convergence.

## Testing

- New testitem `test_as_matrix_free`: field sharing (`===`) for everything that must survive, emptiness of what must not, loud failure of `assemble_stiffness!`/`create_assembler_cache(::AssembledMatrix)`, and agreement of `assemble_matrix_free_action!` and `assemble_diagonal!` with the assembled gold reference on every available backend.
- Full CPU suite passes: 51847/51847.
- Downstream GPU verification on ROCm via Carina's device test suite (explicit + matrix-free quasi-static, GPU vs CPU agreement) passes with the stripped assembler.