### PR TITLE
Fix expression evaluation on NVIDIA GPUs, and size expression trees to fit

### DIFF
--- a/src/AppTools.jl
+++ b/src/AppTools.jl
@@ -332,11 +332,11 @@ end
 
 struct BCSettings{N, T <: Number}
     dict::Dict{String, Any}
-    dirichlet::Vector{DirichletBC{ScalarExpressionFunction{T}}}
-    neumann::Vector{NeumannBC{VectorExpressionFunction{N, T}}}
-    periodic::Vector{PeriodicBC{ScalarExpressionFunction{T}}}
-    robin::Vector{RobinBC{VectorExpressionFunction{N, T}}}
-    source::Vector{Source{VectorExpressionFunction{N, T}}}
+    dirichlet::Vector{DirichletBC{<:ScalarExpressionFunction{T}}}
+    neumann::Vector{NeumannBC{<:VectorExpressionFunction{N, T}}}
+    periodic::Vector{PeriodicBC{<:ScalarExpressionFunction{T}}}
+    robin::Vector{RobinBC{<:VectorExpressionFunction{N, T}}}
+    source::Vector{Source{<:VectorExpressionFunction{N, T}}}
 
     function BCSettings{N, T}(log_file, parser, functions::FunctionSettings{N, T}) where {N, T <: Number}
         print_banner(log_file, "Boundary conditions")
@@ -345,11 +345,11 @@ struct BCSettings{N, T <: Number}
         else
             bc_settings = Dict{String, Any}()
         end
-        dbcs = DirichletBC{ScalarExpressionFunction{T}}[]
-        nbcs = NeumannBC{VectorExpressionFunction{N, T}}[]
-        pbcs = PeriodicBC{ScalarExpressionFunction{T}}[]
-        rbcs = RobinBC{VectorExpressionFunction{N, T}}[]
-        srcs = Source{VectorExpressionFunction{N, T}}[]
+        dbcs = DirichletBC{<:ScalarExpressionFunction{T}}[]
+        nbcs = NeumannBC{<:VectorExpressionFunction{N, T}}[]
+        pbcs = PeriodicBC{<:ScalarExpressionFunction{T}}[]
+        rbcs = RobinBC{<:VectorExpressionFunction{N, T}}[]
+        srcs = Source{<:VectorExpressionFunction{N, T}}[]
         if haskey(bc_settings, "dirichlet")
             dbc_settings = bc_settings["dirichlet"]::Vector{Any}
             for bc in dbc_settings
@@ -445,11 +445,11 @@ struct BCSettings{N, T <: Number}
 end
 
 struct ICSettings{T <: Number}
-    ics::Vector{InitialCondition{ScalarExpressionFunction{T}}}
+    ics::Vector{InitialCondition{<:ScalarExpressionFunction{T}}}
 
     function ICSettings{T}(log_file, parser, functions::FunctionSettings{N, T}) where {N, T}
         print_banner(log_file, "Initial conditions")
-        ics = InitialCondition{ScalarExpressionFunction{Float64}}[]
+        ics = InitialCondition{<:ScalarExpressionFunction{Float64}}[]
         if haskey(parser, "initial conditions")
             ic_settings = parser["initial conditions"]::Vector{Any}
             for ic in ic_settings
@@ -661,15 +661,15 @@ function setup(app::App{D, N}, args::Vector{String}) where {D, N}
 end
 
 struct Simulation{D, N, T <: Number, IO, Mesh}
-    dbcs::Vector{DirichletBC{ScalarExpressionFunction{T}}}
-    ics::Vector{InitialCondition{ScalarExpressionFunction{T}}}
+    dbcs::Vector{DirichletBC{<:ScalarExpressionFunction{T}}}
+    ics::Vector{InitialCondition{<:ScalarExpressionFunction{T}}}
     input_settings::InputSettings{N, T}
     log_file::LogFile{IO}
     mesh::Mesh
-    nbcs::Vector{NeumannBC{VectorExpressionFunction{N, T}}}
-    pbcs::Vector{PeriodicBC{ScalarExpressionFunction{T}}}
-    rbcs::Vector{RobinBC{VectorExpressionFunction{N, T}}}
-    srcs::Vector{Source{VectorExpressionFunction{N, T}}}
+    nbcs::Vector{NeumannBC{<:VectorExpressionFunction{N, T}}}
+    pbcs::Vector{PeriodicBC{<:ScalarExpressionFunction{T}}}
+    rbcs::Vector{RobinBC{<:VectorExpressionFunction{N, T}}}
+    srcs::Vector{Source{<:VectorExpressionFunction{N, T}}}
 
     function Simulation{D, N}(settings::InputSettings, log_file::LogFile{IO}) where {D, N, IO}
         print_banner(log_file, "Mesh")

--- a/src/Expressions.jl
+++ b/src/Expressions.jl
@@ -392,7 +392,27 @@ abstract type AbstractExpressionFunction{T, N, D} <: Function end
 # construction time.
 ########################################################
 
-const FEC_EXPR_MAX_NODES = 256
+# Trees are padded up to the next width on this ladder, and the width is a
+# type parameter of `ScalarExpressionFunction`.  A dynamically indexed
+# by-value NTuple is copied to LOCAL memory PER THREAD on the GPU, so every
+# evaluated node pays for the padding, not for the tree: measured on a V100
+# over 200k BC nodes, a 15-node expression costs 2.31 ns/node padded to 16
+# and 28.38 ns/node padded to 256.  Sizing the pad to the tree is therefore
+# worth ~12x on any BC or IC applied to many nodes.
+#
+# The ladder (rather than an exact width) keeps the number of kernel
+# specialisations bounded — one per distinct width in use, typically two or
+# three for a whole input deck.
+const FEC_EXPR_WIDTHS    = (16, 32, 64, 128, 256, 512, 1024)
+const FEC_EXPR_MAX_NODES = last(FEC_EXPR_WIDTHS)
+
+# Smallest ladder width that holds `n` nodes.
+function _bucket_width(n::Integer)
+    for w in FEC_EXPR_WIDTHS
+        n <= w && return w
+    end
+    error("expression too large: $n nodes (max $FEC_EXPR_MAX_NODES)")
+end
 
 """
 $(TYPEDEF)
@@ -448,8 +468,8 @@ function _flatten_visit!(buf::Vector{FlatNode{T}}, node::Node{T, D})::UInt16 whe
     end
 end
 
-@generated function _vector_to_ntuple(v::Vector{T}) where {T}
-    Expr(:tuple, [:(@inbounds(v[$i])) for i=1:FEC_EXPR_MAX_NODES]...)
+@generated function _vector_to_ntuple(v::Vector{T}, ::Val{M}) where {T, M}
+    Expr(:tuple, [:(@inbounds(v[$i])) for i=1:M]...)
 end
 
 function _flatten(root::Node{T, D}) where {T, D}
@@ -457,16 +477,13 @@ function _flatten(root::Node{T, D}) where {T, D}
     sizehint!(buf, FEC_EXPR_MAX_NODES)
     _flatten_visit!(buf, root)
     n_active = length(buf)
-    n_active <= FEC_EXPR_MAX_NODES || error(
-        "expression too large: $n_active nodes (max $FEC_EXPR_MAX_NODES)"
-    )
-    # Pad to fixed length with default nodes so the resulting NTuple type
-    # has a constant size at the type level.
-    while length(buf) < FEC_EXPR_MAX_NODES
+    # Pad to the next ladder width so the NTuple type has a constant size at
+    # the type level, while still costing only what this tree needs.
+    width = _bucket_width(n_active)
+    while length(buf) < width
         push!(buf, FlatNode{T}())
     end
-    # nodes = NTuple{FEC_EXPR_MAX_NODES, FlatNode{T}}(buf)
-    nodes = _vector_to_ntuple(buf)
+    nodes = _vector_to_ntuple(buf, Val(width))
     return nodes, UInt16(n_active)
 end
 
@@ -565,44 +582,69 @@ KernelAbstractions kernel argument and trim-mode safe under `juliac`.
 The trailing variable is conventionally time; FEC's juliac-safe
 `DirichletBCs` constructor uses `num_vars` as the time-derivative index.
 """
-struct ScalarExpressionFunction{T <: Number} <: AbstractExpressionFunction{T, FlatNode{T}, ntuple_type}
-    nodes::NTuple{FEC_EXPR_MAX_NODES, FlatNode{T}}
+struct ScalarExpressionFunction{T <: Number, N} <: AbstractExpressionFunction{T, FlatNode{T}, ntuple_type}
+    nodes::NTuple{N, FlatNode{T}}
     n_active::UInt16
     num_vars::UInt8
 
-    """
-    $(TYPEDSIGNATURES)
-
-    Parse `string` as an expression in the variable namespace `var_names`
-    and store the resulting tree in flat form.  `var_names` is consumed by
-    the parser to bind identifiers to feature indices; it is not retained
-    on the resulting function.
-    """
-    function ScalarExpressionFunction{T}(string::String, var_names::Vector{String}) where T <: Number
-        p = Parser{T}(string, var_names)
-        _reset!(p)
-        ast = _parse_statement(p, 0)
-        nodes, n_active = _flatten(ast)
-        new{T}(nodes, n_active, UInt8(length(var_names)))
-    end
-
-    """
-    $(TYPEDSIGNATURES)
-
-    Build a `ScalarExpressionFunction` from a prebuilt flat NTuple — used
-    internally by [`differentiate`](@ref) to wrap the result of a tree
-    rewrite without round-tripping through the parser.
-    """
-    function ScalarExpressionFunction{T}(
-        nodes::NTuple{FEC_EXPR_MAX_NODES, FlatNode{T}},
+    function ScalarExpressionFunction{T, N}(
+        nodes::NTuple{N, FlatNode{T}},
         n_active::UInt16,
         num_vars::Integer
-    ) where T <: Number
-        new{T}(nodes, n_active, UInt8(num_vars))
+    ) where {T <: Number, N}
+        new{T, N}(nodes, n_active, UInt8(num_vars))
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Parse `string` as an expression in the variable namespace `var_names` and
+store the resulting tree in flat form.  `var_names` is consumed by the
+parser to bind identifiers to feature indices; it is not retained on the
+resulting function.  The tuple width is chosen from `FEC_EXPR_WIDTHS` to
+fit this tree, so the returned type is `ScalarExpressionFunction{T, N}`
+with N depending on the expression.
+"""
+function ScalarExpressionFunction{T}(string::String, var_names::Vector{String}) where T <: Number
+    p = Parser{T}(string, var_names)
+    _reset!(p)
+    ast = _parse_statement(p, 0)
+    nodes, n_active = _flatten(ast)
+    return ScalarExpressionFunction{T, length(nodes)}(nodes, n_active,
+                                                      UInt8(length(var_names)))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `ScalarExpressionFunction` from a prebuilt flat NTuple — used
+internally by [`differentiate`](@ref) to wrap the result of a tree rewrite
+without round-tripping through the parser.
+"""
+function ScalarExpressionFunction{T}(
+    nodes::NTuple{N, FlatNode{T}},
+    n_active::UInt16,
+    num_vars::Integer
+) where {T <: Number, N}
+    return ScalarExpressionFunction{T, N}(nodes, n_active, num_vars)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Re-pad `f` to a wider tuple.  Needed where several expressions must share
+one concrete type — `VectorExpressionFunction` holds its components in an
+`SVector`, which has to be homogeneous.
+"""
+function _repad(f::ScalarExpressionFunction{T, N}, ::Val{M}) where {T, N, M}
+    M >= N || error("cannot re-pad a width-$N expression down to $M")
+    nodes = ntuple(i -> i <= N ? f.nodes[i] : FlatNode{T}(), Val(M))
+    return ScalarExpressionFunction{T, M}(nodes, f.n_active, f.num_vars)
+end
+
 Base.eltype(::ScalarExpressionFunction{T}) where T <: Number = T
+Base.length(::ScalarExpressionFunction{T, N}) where {T, N} = N
 
 # Single scalar
 function (f::ScalarExpressionFunction{T})(var::T) where T <: Number
@@ -654,21 +696,31 @@ $(METHODLIST)
 $(TYPEDFIELDS)
 $(TYPEDEF)
 """
-struct VectorExpressionFunction{N, T <: Number} <: AbstractExpressionFunction{T, Node{T, DEFAULT_MAX_DEGREE}, ntuple_type}
-    exprs::SVector{N, ScalarExpressionFunction{T}}
+struct VectorExpressionFunction{N, T <: Number, M} <: AbstractExpressionFunction{T, Node{T, DEFAULT_MAX_DEGREE}, ntuple_type}
+    exprs::SVector{N, ScalarExpressionFunction{T, M}}
     num_vars::Int
 
-    function VectorExpressionFunction{N, T}(
-        strings::Vector{String},
-        var_names::Vector{String},
-    ) where {N, T<:Number}
-        @assert length(strings) == N
-        funcs = ntuple(
-            i -> ScalarExpressionFunction{T}(strings[i], var_names),
-            Val(N),
-        )
-        return new{N, T}(SVector{N}(funcs), length(var_names))
+    function VectorExpressionFunction{N, T, M}(
+        exprs::SVector{N, ScalarExpressionFunction{T, M}},
+        num_vars::Integer
+    ) where {N, T <: Number, M}
+        return new{N, T, M}(exprs, Int(num_vars))
     end
+end
+
+# The components are parsed independently and may land on different ladder
+# widths; the SVector needs one concrete element type, so widen them all to
+# the widest.
+function VectorExpressionFunction{N, T}(
+    strings::Vector{String},
+    var_names::Vector{String},
+) where {N, T <: Number}
+    @assert length(strings) == N
+    funcs = ntuple(i -> ScalarExpressionFunction{T}(strings[i], var_names), Val(N))
+    M = maximum(length, funcs)
+    padded = ntuple(i -> _repad(funcs[i], Val(M)), Val(N))
+    return VectorExpressionFunction{N, T, M}(
+        SVector{N, ScalarExpressionFunction{T, M}}(padded), length(var_names))
 end
 
 function (f::VectorExpressionFunction)(var::T) where T <: Number

--- a/src/Expressions.jl
+++ b/src/Expressions.jl
@@ -1,5 +1,6 @@
 module Expressions
 
+import Adapt
 import DynamicExpressions.NodeModule: DEFAULT_MAX_DEGREE
 using DocStringExtensions
 using DynamicExpressions
@@ -685,6 +686,24 @@ end
 function (f::VectorExpressionFunction)(X::SVector{ND, T}, t::T) where {ND, T <: Number}
     return map(func -> func(X, t), f.exprs)
 end
+
+########################################################
+# Adapt
+#
+# Both flat expression functions subtype `Function` so they can be called,
+# but they are plain isbits data — no captured arrays, nothing to move to a
+# device.  Adapt's generic `Function` method assumes any callable is a
+# closure and infers one type parameter per captured field: for
+# `ScalarExpressionFunction{T}` that is 1 type parameter against 3 fields,
+# so it computes `num_static_params = -2` and throws
+# `ArgumentError: tuple length should be >= 0, got -2`.  That fires the
+# moment one of these is passed to a GPU kernel as a bare argument rather
+# than reached through an enclosing closure.  Adapting them is the
+# identity.
+########################################################
+
+Adapt.adapt_structure(to, f::ScalarExpressionFunction) = f
+Adapt.adapt_structure(to, f::VectorExpressionFunction) = f
 
 ########################################################
 # Symbolic differentiation on the recursive Node form.

--- a/src/Expressions.jl
+++ b/src/Expressions.jl
@@ -517,26 +517,42 @@ end
     return T(NaN)
 end
 
-# Recursive evaluator over the flat NTuple.  Depth is bounded by the
-# expression tree height (≤ ~10 for the expressions Carina uses today),
-# so GPUCompiler handles the recursion without stack pressure.
-function _eval_node(nodes::NTuple{N, FlatNode{T}}, idx::UInt16,
-                    vars) where {N, T}
-    n = nodes[idx]
-    if n.degree == 0
-        if n.constant
-            return n.val
+# Iterative evaluator over the flat NTuple.
+#
+# MUST NOT RECURSE.  `nodes` is an NTuple passed by value, and indexing it
+# with a runtime index forces the whole tuple (6152 B at the default
+# `FEC_EXPR_MAX_NODES`) into an addressable stack slot.  A recursive walk
+# therefore needs one such frame per level, and because ptxas cannot bound
+# the depth of a recursive call it sizes the per-thread stack from CUDA's
+# `cuLimitStackSize`, which defaults to 1024 B.  Every device-side BC/IC
+# evaluation then overflowed the stack on its very first call — even for
+# the single-node expression "0.0" — and surfaced as
+# `ERROR_ILLEGAL_ADDRESS` from an unrelated later launch.  ROCm's larger
+# default scratch allocation hid the same bug, so this only ever showed up
+# on NVIDIA.  Written as a loop, the frame is statically sized and ptxas
+# allocates local memory for it directly; no stack-limit tuning needed.
+#
+# `_flatten_visit!` reserves a parent's slot before descending, so every
+# child index is strictly greater than its parent's.  Sweeping
+# `n_active:-1:1` is therefore a valid bottom-up order: when a node is
+# reached, both of its children already hold values.  The root is at
+# index 1 by construction.
+@inline function _eval_node(nodes::NTuple{N, FlatNode{T}}, n_active::UInt16,
+                            vars) where {N, T}
+    vals = MVector{N, T}(undef)
+    i = Int(n_active)
+    @inbounds while i >= 1
+        n = nodes[i]
+        if n.degree == 0
+            vals[i] = n.constant ? n.val : T(vars[n.feature])
+        elseif n.degree == 1
+            vals[i] = _apply_unary_op(T, n.op, vals[n.l_idx])
         else
-            return T(vars[n.feature])
+            vals[i] = _apply_binary_op(T, n.op, vals[n.l_idx], vals[n.r_idx])
         end
-    elseif n.degree == 1
-        u = _eval_node(nodes, n.l_idx, vars)
-        return _apply_unary_op(T, n.op, u)
-    else
-        u = _eval_node(nodes, n.l_idx, vars)
-        v = _eval_node(nodes, n.r_idx, vars)
-        return _apply_binary_op(T, n.op, u, v)
+        i -= 1
     end
+    return @inbounds vals[1]
 end
 
 """
@@ -590,13 +606,13 @@ Base.eltype(::ScalarExpressionFunction{T}) where T <: Number = T
 # Single scalar
 function (f::ScalarExpressionFunction{T})(var::T) where T <: Number
     @assert f.num_vars == 1
-    return _eval_node(f.nodes, UInt16(1), SVector{1, T}(var))
+    return _eval_node(f.nodes, f.n_active, SVector{1, T}(var))
 end
 
 # Vector of variable values (no `t` overload)
 function (f::ScalarExpressionFunction{T})(vars::AbstractVector{T}) where T <: Number
     @assert length(vars) == Int(f.num_vars) "expected $(Int(f.num_vars)) variables, got $(length(vars))"
-    return _eval_node(f.nodes, UInt16(1), vars)
+    return _eval_node(f.nodes, f.n_active, vars)
 end
 
 # IC-style call: ND spatial coords (no time variable in the expression).
@@ -605,7 +621,7 @@ function (f::ScalarExpressionFunction{T})(X::SVector{ND, T}) where {ND, T <: Num
     # `_update_ic_values!` dispatches on the IC container's backend, so this call
     # lands inside a KA kernel whenever the parameters live on the device.
     @assert Int(f.num_vars) == ND "wrong number of variables for this expression"
-    return _eval_node(f.nodes, UInt16(1), X)
+    return _eval_node(f.nodes, f.n_active, X)
 end
 
 # BC-style call: ND spatial coords + scalar time, packed into a stack-
@@ -629,7 +645,7 @@ function (f::ScalarExpressionFunction{T})(X::SVector{ND, T}, t::T) where {ND, T 
         # Generic path (very unlikely; covered for completeness).  Allocates.
         vars = T[X...; t]
     end
-    return _eval_node(f.nodes, UInt16(1), vars)
+    return _eval_node(f.nodes, f.n_active, vars)
 end
 
 """

--- a/src/bcs/DirichletBCs.jl
+++ b/src/bcs/DirichletBCs.jl
@@ -175,7 +175,11 @@ struct DirichletBCFunction{F1, F2, F3} <: AbstractBCFunction{F1}
     t_idx        = Int(func.num_vars)
     func_dot     = Expressions.differentiate(func, t_idx)
     func_dot_dot = Expressions.differentiate(func_dot, t_idx)
-    new{F, F, F}(func, func_dot, func_dot_dot)
+    # Derivative trees grow, so each component may land on a different
+    # `FEC_EXPR_WIDTHS` rung; the three type parameters exist precisely so
+    # they need not agree.  Padding them to a common width would make every
+    # BC pay the second derivative's footprint on every evaluation.
+    new{F, typeof(func_dot), typeof(func_dot_dot)}(func, func_dot, func_dot_dot)
   end
 
   function DirichletBCFunction{F1, F2, F3}(

--- a/test/TestExpressions.jl
+++ b/test/TestExpressions.jl
@@ -188,9 +188,13 @@ end
 @testitem "ScalarExpressionFunction - is isbits (GPU + juliac safe)" begin
     import FiniteElementContainers.Expressions: ScalarExpressionFunction, FlatNode
     @test isbitstype(FlatNode{Float64})
-    @test isbitstype(ScalarExpressionFunction{Float64})
     f = ScalarExpressionFunction{Float64}("a*exp(-(t-tc)^2 / (2*tau^2))",
                                           ["a", "tc", "tau", "t"])
+    # The flat tuple's width is a type parameter chosen per expression, so
+    # `ScalarExpressionFunction{Float64}` is a UnionAll and cannot itself be a
+    # bits type.  What has to be isbits — for both KA kernel arguments and
+    # juliac --trim — is the concrete type the constructor produces.
+    @test isbitstype(typeof(f))
     @test isbits(f)
 end
 


### PR DESCRIPTION
Evaluating a parsed expression inside a kernel faulted on every NVIDIA GPU, for
every expression, including `"0.0"`. Any input-file driven problem carrying a
Dirichlet BC or an initial condition died on its first time step with
`ERROR_ILLEGAL_ADDRESS`. ROCm was unaffected, which is why this survived #328.

While fixing it I found that the flat form charges every evaluation for the
node cap rather than for the tree, which is the wrong unit of cost for a BC or
IC applied to many nodes, and which had also made realistic expressions
unrepresentable.

## The evaluator recursed, and CUDA gave it a 1 KB stack

`_eval_node` walked the flattened tree recursively, passing `nodes` — an
`NTuple{256, FlatNode{Float64}}`, 6152 bytes — by value in every frame.
Indexing that tuple with a runtime index forces it into an addressable stack
slot, so each level of recursion costs a full copy.

ptxas cannot bound the depth of a recursive call, so it does not compute a
frame size; CUDA falls back to `cuLimitStackSize`, which defaults to **1024
bytes**. One frame needs six times that. Every device-side BC and IC
evaluation therefore overflowed the stack on its very first call, no matter how
small the expression — the single-node `"0.0"` faults exactly like a 25-node
one, because the frame is sized by the type, not by the tree.

The failure surfaced far from its cause. The reported stack trace pointed at
whatever kernel launch happened to come next (`update_field_dirichlet_bcs!`, or
a `cuModuleLoadDataEx` during compilation), and the run then emitted forty-odd
cascading finalizer errors from the poisoned context. `CUDA_LAUNCH_BLOCKING=1`
pins it to `_update_bc_values!`.

ROCm's default scratch allocation is far larger, so the identical defect never
manifested there.

`_flatten_visit!` reserves a parent's slot before descending, so every child
index is strictly greater than its parent's. Sweeping `n_active:-1:1` is
therefore a valid bottom-up order — when a node is reached, both of its
children already hold values — and the resulting loop has a statically sized
frame that ptxas allocates local memory for directly.

Raising `cuLimitStackSize` also makes the symptom go away, and is not a fix:
CUDA reserves that stack for every resident thread, so the ~60 KB a depth-10
tree needs works out to roughly 10 GB on a V100.

## Adapt treated the expression functions as closures

`ScalarExpressionFunction` and `VectorExpressionFunction` subtype `Function` so
they can be called, but they hold plain isbits data. Adapt's generic `Function`
method assumes any callable is a closure and infers one type parameter per
captured field; for `ScalarExpressionFunction{T}` that is 1 type parameter
against 3 fields, so it computes `num_static_params = 1 - 3 = -2` and throws
`ArgumentError: tuple length should be >= 0, got -2`.

This fires the moment one is handed to a kernel as a bare argument. Today the
BC and IC paths only reach them through an enclosing closure, whose isbits
fields Adapt leaves alone, so the landmine has stayed unarmed — I tripped it
writing a minimal reproducer. Adapting them is the identity.

## Every expression paid for a 256-node pad

A by-value `NTuple` that is dynamically indexed is copied to local memory *per
thread*, so each evaluated node pays for the padding, not for its tree. On a
V100 over 200k BC nodes, a 15-node expression costs:

```
  padded to  16     2.31 ns/node
  padded to  32     4.07
  padded to  64     7.49
  padded to 128    14.32
  padded to 256    28.38      <- what every expression got
```

That 12x is borne by exactly the BCs and ICs that are applied to many nodes.
The width is now a type parameter chosen per expression from a ladder
(16/32/64/128/256/512/1024); a ladder rather than an exact width keeps the
number of kernel specialisations bounded, and a whole input deck typically uses
two or three.

For comparison I also prototyped moving the tree to a device array shared
across threads, which is flat at ~1.8 ns/node regardless of width. It is only
~20% better than right-sizing at realistic tree sizes and costs the isbits and
`juliac --trim` properties the flat form exists to provide, so I did not pursue
it. It remains the answer if a 500-node expression ever lands on a large node
set.

Right-sizing also lifts a real limit. The old cap rejected plausible BCs at
construction, because symbolic time differentiation grows the tree: the second
derivative of a windowed Gaussian pulse
`exp(-((t-0.5)/0.1)^2)*sin(20t)*(1-exp(-t/0.05))` is 347 nodes, and of
`sqrt(x^2+y^2+z^2)*tanh(t)*log(1+t^2)/(1+cosh(t))` is 410. Both now build, on
the 512 rung, without imposing that width on anything else.

Three consequences worth flagging for review:

- `DirichletBCFunction` now lets `f`, `f'` and `f''` land on different rungs.
  Its three type parameters already allowed this; padding them to a common
  width would make every BC pay the second derivative's footprint on every
  evaluation.
- `VectorExpressionFunction` holds its components in an `SVector`, which must
  be homogeneous, so those are widened to their maximum via `_repad` and the
  shared width becomes a third type parameter.
- Container element types are invariant, so declarations such as
  `Vector{DirichletBC{ScalarExpressionFunction{T}}}` no longer admit a
  width-carrying instance; those are now `<:`-qualified. `Dict` value slots
  take the UnionAll directly and are unchanged.

## Why the suite did not catch the outage

`TestExpressions.jl` exercises the evaluator thoroughly, but on the host, where
recursion is free. The `:gpu`-tagged tests added in #328 do drive a parsed
expression through `update_bc_values!` and `initialize!` on a device — the
right test, and it would have caught this — but CI and local runs for this
package are ROCm, where the larger default scratch hides it. Nothing here was
run against CUDA.

I have not added a test that pins the stack behaviour, because I could not find
one that fails for the right reason: the recursion is a property of the
generated code, not of any value the suite can inspect, and on ROCm the broken
version passes. The existing `:gpu` expression tests are the guard, and they do
catch it — under `--test-cuda`.

## Verification

On a Tesla V100-PCIE-32GB, CUDA 12.9, driver 13.0, Julia 1.12.6:

- Carina's 530,523-DOF torsion quasi-static case (`device: cuda`, CG + GPU AMG)
  went from `ERROR_ILLEGAL_ADDRESS` on the first Newton step to 4/4 load steps
  with quadratic convergence, `|U|_max = 1.28e-03`.
- A 27,783-DOF cube reproducer fails and passes identically, confirming this is
  not size-dependent.
- The iterative evaluator agrees with the recursive walk to 1e-12 over 15
  expressions x 3 time derivatives x 4 evaluation points, covering every unary
  and binary op in the grammar.
- A bare `ScalarExpressionFunction` now survives `Adapt.adapt` and a kernel
  launch, returning the host value.
- Both expression types are still `isbits`.
- CPU cost is unchanged at the deployed width (53.3 vs 54.3 ns/node over a
  2646-node BC sweep, zero allocations in both).

Narrower tuples also mean much less work for LLVM. On the torsion case, setup
falls from 2m29s to 1m13s and total wall time from 6m30s to 5m05s.

This package's suite passes 51847/51847.  The one assertion that had to
change is `TestExpressions.jl`'s isbits check, which asserted on the type
`ScalarExpressionFunction{Float64}` — now a UnionAll, so not itself a bits
type.  It asserts on the concrete constructed type instead, which is what
actually has to be isbits for kernel arguments and for `juliac --trim`.

Downstream, Carina's suite passes 809.
