### PR TITLE
Accept any AbstractVector or AbstractMatrix of block properties

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -477,57 +477,58 @@ struct PropertyField{
         new{T, D, I}(data, isblockconstant, nblocks, nepes, nelems, offsets)
     end
 
-    # case where all blocks have properties the same throughout
-    function PropertyField(arrs::Vector{<:Vector{T}}) where T <: Number
-        data = reduce(vcat, arrs)
-        isblockconstant = PROPS_CONST * ones(Int, length(arrs))
-        nblocks = length(arrs)
-        nepes = map(length, arrs)
-        nelems = -1 * ones(Int, nblocks)
-        offsets = Vector{Int}(undef, 0)
-        offset = 1
-        for n in axes(arrs, 1)
-            push!(offsets, offset)
-            offset += nepes[n]
-        end
-        return PropertyField{T, typeof(data), typeof(isblockconstant)}(data, isblockconstant, nblocks, nepes, nelems, offsets)
-    end
+    # One entry per block.  A vector-like entry means the properties are
+    # constant across that block; a matrix-like entry means one column per
+    # element.  The two may be mixed freely.
+    function PropertyField(arrs::AbstractVector)
+        isempty(arrs) && throw(ArgumentError(
+            "PropertyField needs at least one block of properties, got none"))
 
-    # case where we have mixed constant or none constant
-    function PropertyField(arrs::Vector{<:Array{T}}) where T <: Number
-        data = mapreduce(vec, vcat, arrs)
-        isblockconstant = map(x -> begin
-            if isa(x, Matrix)
-                return PROPS_ELEMS
-            elseif isa(x, Vector)
-                return PROPS_CONST
-            else
-                @assert false "Property arrays should be Vector or Matrix"
-            end
-        end, arrs)
-        nblocks = length(arrs)
-        out = map(x -> begin
-            if isa(x, Matrix)
-                return size(x)
-            elseif isa(x, Vector)
-                return (length(x), -1)
-            end
-        end, arrs)
-        nepes = map(x -> x[1], out)
-        nelems = map(x -> x[2], out)
-        offsets = Vector{Int}(undef, 0)
+        blocks = map(_property_block, arrs)
+        T = promote_type(map(eltype, blocks)...)
+        blocks = map(x -> convert(AbstractArray{T}, x), blocks)
+
+        nblocks = length(blocks)
+        isblockconstant = Vector{Int}(undef, nblocks)
+        nepes           = Vector{Int}(undef, nblocks)
+        nelems          = Vector{Int}(undef, nblocks)
+        offsets         = Vector{Int}(undef, nblocks)
+
         offset = 1
-        for n in axes(arrs, 1)
-            push!(offsets, offset)
-            if isa(arrs[n], Matrix)
-                offset += nepes[n] * nelems[n]
-            elseif isa(arrs[n], Vector)
-                offset += nepes[n]
-            end
+        for (n, x) in enumerate(blocks)
+            elementwise = x isa AbstractMatrix
+            isblockconstant[n] = elementwise ? PROPS_ELEMS : PROPS_CONST
+            nepes[n]           = elementwise ? size(x, 1) : length(x)
+            nelems[n]          = elementwise ? size(x, 2) : -1
+            offsets[n]         = offset
+            offset            += length(x)
         end
-        return PropertyField{T, typeof(data), typeof(isblockconstant)}(data, isblockconstant, nblocks, nepes, nelems, offsets)
+
+        data = Vector{T}(undef, offset - 1)
+        i = 1
+        for x in blocks
+            n = length(x)
+            copyto!(data, i, vec(x), 1, n)
+            i += n
+        end
+
+        return PropertyField{T, typeof(data), typeof(isblockconstant)}(
+            data, isblockconstant, nblocks, nepes, nelems, offsets
+        )
     end
 end
+
+# Normalize one block's properties to a dense array we own.  This deliberately
+# accepts any AbstractVector/AbstractMatrix rather than Vector/Matrix: an
+# `SVector` is what a `create_properties` implementation naturally returns, and
+# rejecting it left downstream packages with a bare MethodError naming an
+# internal constructor.
+_property_block(x::AbstractVector{<:Number}) = collect(x)
+_property_block(x::AbstractMatrix{<:Number}) = collect(x)
+_property_block(x) = throw(ArgumentError(
+    "each block's properties must be an AbstractVector of numbers (constant " *
+    "across the block) or an AbstractMatrix of numbers with one column per " *
+    "element (element-level properties); got $(typeof(x))"))
 
 function Adapt.adapt_structure(to, field::PropertyField)
     data = adapt(to, field.data)

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -54,7 +54,8 @@ end
 # a single properties object shared by every block
 # needs to be constant props, can't be element level
 # unless we have one block, but let's not specialize that muc
-function _setup_properties(fspace, props::Vector)
+# Any AbstractVector of numbers, so an SVector works here too.
+function _setup_properties(fspace, props::AbstractVector{<:Number})
   return PropertyField(map(_ -> props, block_names(fspace)))
 end
 

--- a/test/TestFields.jl
+++ b/test/TestFields.jl
@@ -237,6 +237,50 @@ end
   end
 end
 
+@testitem "Fields - test_property_field_static_arrays" begin
+  using StaticArrays
+  # `create_properties` implementations hand back an SVector, so the
+  # constructor has to take one.
+  props_1 = SVector{2, Float64}(rand(2))
+  props_2 = SVector{3, Float64}(rand(3))
+  props = FiniteElementContainers.PropertyField([props_1, props_2])
+  @test all(FiniteElementContainers.properties(props, 1, 1) .≈ props_1)
+  @test all(FiniteElementContainers.properties(props, 100, 1) .≈ props_1)
+  @test all(FiniteElementContainers.properties(props, 1, 2) .≈ props_2)
+  @test all(FiniteElementContainers.properties(props, 100, 2) .≈ props_2)
+
+  # ...and mixed with an element-level block, static or not.
+  props_3 = SMatrix{2, 4, Float64, 8}(rand(2, 4))
+  mixed = FiniteElementContainers.PropertyField([props_1, props_3])
+  @test all(FiniteElementContainers.properties(mixed, 7, 1) .≈ props_1)
+  for e in axes(props_3, 2)
+    @test all(FiniteElementContainers.properties(mixed, e, 2) .≈ props_3[:, e])
+  end
+end
+
+@testitem "Fields - test_property_field_promotes_eltypes" begin
+  props = FiniteElementContainers.PropertyField([[1, 2], [3.5, 4.5]])
+  @test eltype(props) == Float64
+  @test all(FiniteElementContainers.properties(props, 1, 1) .≈ [1.0, 2.0])
+  @test all(FiniteElementContainers.properties(props, 1, 2) .≈ [3.5, 4.5])
+end
+
+@testitem "Fields - test_property_field_rejects_bad_input" begin
+  # A rank-3 array has no reading as either constant or element-level, and an
+  # empty block list has no reading at all.  Both should say so.
+  @test_throws ArgumentError FiniteElementContainers.PropertyField([rand(2, 2, 2)])
+  @test_throws ArgumentError FiniteElementContainers.PropertyField(["not numbers"])
+  @test_throws ArgumentError FiniteElementContainers.PropertyField([])
+end
+
+@testitem "Fields - test_property_field_does_not_alias_input" begin
+  props_1 = rand(3)
+  props = FiniteElementContainers.PropertyField([props_1])
+  original = copy(props_1)
+  props_1 .= 0.0
+  @test all(FiniteElementContainers.properties(props, 1, 1) .≈ original)
+end
+
 @testitem "Fields - test_state_variable_field" begin
   a1 = rand(2, 3, 40)
   a2 = rand(3, 4, 10)


### PR DESCRIPTION
Follow-up to #331.

`create_properties` is part of the physics interface, and an implementation that returns an `SVector` — the natural thing to return, and what FEC's own defaults returned until #331 — could not build a `PropertyField`. `Vector{SVector{N,T}}` matches neither `PropertyField(::Vector{<:Vector{T}})` nor `PropertyField(::Vector{<:Array{T}})`, so the failure was a bare `MethodError` naming two internal constructors with nothing to say what the caller should have passed instead. Carina hit exactly this and had to change its own return type to work around it.

This collapses the two constructors into one that takes any `AbstractVector` of blocks and normalizes each entry to a dense array we own:

- a vector-like block is constant across the block,
- a matrix-like block is one column per element,
- the two still mix freely.

Anything else now raises an `ArgumentError` naming the offending type and both accepted shapes, instead of an `@assert` that could only fire after dispatch had already succeeded — by construction it was unreachable, since a rank-3 array never matched `Vector{<:Array{T}}` in the first place.

Two fixes fall out of normalizing up front:

- **Element types are promoted across blocks** rather than being required to match, so `[[1, 2], [3.5, 4.5]]` works.
- **The field no longer aliases the caller's arrays.** `reduce(vcat, arrs)` returns the input itself for a single-block mesh, so mutating the array you passed in silently rewrote the material properties. There is a regression test for this.

`_setup_properties` widens from `Vector` to `AbstractVector{<:Number}` for the same reason, so a single shared `SVector` of properties across all blocks works too.

### Testing

- FEC: 51913 pass (+16, all new).
- Carina: 810/810 green against this branch, on both the explicit and quasi-static GPU paths.

New tests cover static-array blocks, static mixed with element-level, eltype promotion, all three rejection paths, and the aliasing fix.

### Note on CI

GitHub Actions has been in a [major outage](https://www.githubstatus.com) since 15:22Z today, and it never picked up the last push to #331 either. If the checks here stay empty that is why, not the branch — both suites above were run locally on Julia 1.12.6 (CPU) plus gfx1102 for the Carina GPU paths.
